### PR TITLE
deploy: simple helm chart for embed application

### DIFF
--- a/.github/workflows/test-helm.yml
+++ b/.github/workflows/test-helm.yml
@@ -32,6 +32,6 @@ jobs:
 
     - name: helmfile lint
       run: |-
-        cd ./deploy && helmfile lint
+        cd ./deploy && EMBED_IMAGE_REPOSITORY=embed:latest helmfile lint
 
 

--- a/deploy/charts/app/.helmignore
+++ b/deploy/charts/app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/app/Chart.yaml
+++ b/deploy/charts/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: embed
+description: A Helm chart for running embedding server over gRPC
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/charts/app/templates/_helpers.tpl
+++ b/deploy/charts/app/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "embed.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "embed.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "embed.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "embed.labels" -}}
+helm.sh/chart: {{ include "embed.chart" . }}
+{{ include "embed.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "embed.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "embed.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "embed.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "embed.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/app/templates/serviceaccount.yaml
+++ b/deploy/charts/app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "embed.serviceAccountName" . }}
+  labels:
+    {{- include "embed.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/app/templates/serving.yaml
+++ b/deploy/charts/app/templates/serving.yaml
@@ -1,0 +1,51 @@
+{{- $image := .Values.image.repository | required ".Values.image.repository is required." -}}
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: {{ include "embed.fullname" . }}
+  namespace: {{  .Values.namespace }}
+  labels:
+    {{- include "embed.labels" . | nindent 4 }}
+spec:
+  template:
+    name: {{ (list (include "embed.fullname" .) uuidv4 | join "-") }}
+    metadata:
+      {{- with .Values.autoscaling }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "embed.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "embed.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ $image }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.service.port }}
+              protocol: {{ .Values.service.protocol }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/app/templates/serving.yaml
+++ b/deploy/charts/app/templates/serving.yaml
@@ -23,17 +23,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "embed.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ $image }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ $image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: grpc
-              containerPort: {{ .Values.service.port }}
+            - containerPort: {{ .Values.service.port }}
               protocol: {{ .Values.service.protocol }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/charts/app/templates/tests/test-connection.yaml
+++ b/deploy/charts/app/templates/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "embed.fullname" . }}-test-connection"
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "embed.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "embed.fullname" . }}.{{ .Values.namespace }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/deploy/charts/app/values.yaml
+++ b/deploy/charts/app/values.yaml
@@ -22,9 +22,9 @@ fullnameOverride: ""
 ## auto-scaling configuration for embed serving deployment.
 #
 autoscaling:
-  autoscaling.knative.dev/min-scale: 1
-  autoscaling.knative.dev/max-scale: 10
-  autoscaling.knative.dev/target: 4
+  autoscaling.knative.dev/min-scale: "1"
+  autoscaling.knative.dev/max-scale: "10"
+  autoscaling.knative.dev/target: "4"
 
 service:
   ## port is the exposed port of the knative service.

--- a/deploy/charts/app/values.yaml
+++ b/deploy/charts/app/values.yaml
@@ -1,0 +1,71 @@
+# Default values for embed.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## namespace to install embed serving component in.
+#
+namespace: models
+
+## image of embed serving component.
+#
+image:
+  ## repository of image must be explicitly passed in
+  #
+  repository: ""
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+## auto-scaling configuration for embed serving deployment.
+#
+autoscaling:
+  autoscaling.knative.dev/min-scale: 1
+  autoscaling.knative.dev/max-scale: 10
+  autoscaling.knative.dev/target: 4
+
+service:
+  ## port is the exposed port of the knative service.
+  #
+  port: 8080
+  ## protocol to expose service.port on. RPC calls use HTTP/2 under the 
+  ## hood therefore we are using TCP here.
+  #
+  protocol: TCP
+
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+serviceAccount:
+  create: true
+  # Annotations to add to the service account
+  # TODO (jack, 07/08/2023): annotations for gke workload identity?
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""

--- a/deploy/helmfile.yaml
+++ b/deploy/helmfile.yaml
@@ -54,6 +54,8 @@ releases:
     namespace: istio-system
     version: 1.18.2
     chart: istio/istiod
+    needs:
+      - istio-system/istio-base
     <<: *default
 
   - name: prometheus

--- a/deploy/helmfile.yaml
+++ b/deploy/helmfile.yaml
@@ -64,3 +64,10 @@ releases:
     chart: prometheus-community/prometheus
     <<: *default
 
+  - name: embed
+    namespace: models
+    chart: ./charts/app/
+    <<: *default
+    set:
+      - name: image.repository
+        value: {{ requiredEnv "EMBED_IMAGE_REPOSITORY" }}

--- a/deploy/scripts/install-knative.sh
+++ b/deploy/scripts/install-knative.sh
@@ -16,3 +16,5 @@ check-env
 kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${KNATIVE_VERSION}/serving-crds.yaml"
 kubectl apply -f "https://github.com/knative/serving/releases/download/knative-v${KNATIVE_VERSION}/serving-core.yaml"
 kubectl apply -f "https://github.com/knative/net-istio/releases/download/knative-v${KNATIVE_VERSION}/net-istio.yaml"
+
+# TODO: Configuration of knative global feature maps to enable node selectors and security profiles etc.

--- a/deploy/values/embed.yaml
+++ b/deploy/values/embed.yaml
@@ -1,0 +1,1 @@
+## non-default values for embed (application chart)


### PR DESCRIPTION
* deploy: embedding serving ran as a knative service packaged up in a simple helm chart.
* deploy: chart is deployed via helmfile as with all other k8s charts.